### PR TITLE
Custom uploader settings moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Download the `ShareXen.sxcu` file from this repository and double-click it.
 If you can't open it for whatever reason, follow that procedure:
 
 1. Open ShareX, click on `Destinations` then `Custom uploader settings…`.
-3. Click the `Import` dropdown menu, and import the uploader file.
+2. Click the `Import` dropdown menu, and import the uploader file.
 
 You will need to edit the `Request URL` field to match your own domain name and script path, along with the `token` argument value that must contain a valid user token previously defined within the API itself.
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Files will be uploaded next to the script, in the same folder.
 Download the `ShareXen.sxcu` file from this repository and double-click it.  
 If you can't open it for whatever reason, follow that procedure:
 
-1. Open ShareX, click on `Destinations` then `Destination settings…`.
-2. Scroll to the bottom of the list and click on `Custom uploaders`.
+1. Open ShareX, click on `Destinations` then `Custom uploader settings…`.
 3. Click the `Import` dropdown menu, and import the uploader file.
 
 You will need to edit the `Request URL` field to match your own domain name and script path, along with the `token` argument value that must contain a valid user token previously defined within the API itself.


### PR DESCRIPTION
The custom uploader settings were moved from destinations>destination settings>custom uploaders to destinations>custom uploader settings, which I fixed in the readme.