### PR TITLE
Change password generator URL

### DIFF
--- a/sharexen.php
+++ b/sharexen.php
@@ -33,7 +33,7 @@ define('USERS', [
 // be able to delete files without security keys
 // Mandatory for having deletion URLs, set this to
 // a very long and random string of various characters
-// Random generator: https://bfnt.io/pwgen
+// Random generator: https://passwordsgenerator.net/
 define('SALT', 'change-me');
 
 // List of allowed image extensions

--- a/sharexen.php
+++ b/sharexen.php
@@ -18,7 +18,7 @@
 // intended recipient, this can be very dangerous
 // Set tokens to very long and random strings of
 // various characters nobody can ever guess
-// Random generator: https://bfnt.io/pwgen
+// Random generator: https://bit.ly/2DxaTak
 define('USERS', [
 	'Mario' => 'change-me',
 	'Luigi' => 'change-me',
@@ -33,7 +33,7 @@ define('USERS', [
 // be able to delete files without security keys
 // Mandatory for having deletion URLs, set this to
 // a very long and random string of various characters
-// Random generator: https://passwordsgenerator.net/
+// Random generator: https://bit.ly/2DxaTak
 define('SALT', 'change-me');
 
 // List of allowed image extensions


### PR DESCRIPTION
The old one is not valid anymore. It returns `bfnt.io’s server IP address could not be found.` (on chromium based browsers). I replaced it with [passwordsgenerator.net](https://passwordsgenerator.net/).